### PR TITLE
Add TSC members

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -17,7 +17,15 @@ Wherever possible, the TSCs should choose shared policies and infrastructure whi
 Although the TSC may update the TSC governance (e.g. this document) as it finds appropriate, revisions are subject to PMC review and veto, as ultimate authority over governing the ODK project rests with the PMC. Any update to the TSC governing document must be approved by the majority of the PMC. It is expected that the TSC will have a collaborative relationship (perhaps some overlap in membership) with the PMC.
  
 The current list of TSC members are:
-* [Example Person](https://github.com/example), Example Organization
+* Shobhit Agarwal [@shobhitagarwal1612](https://github.com/shobhitagarwal1612), [Tonbo Imaging](http://www.tonboimaging.com/)
+* Alex Anderson [@alxndrsn](https://github.com/alxndrsn), [Medic Mobile](https://medicmobile.org/)
+* Yaw Anokwa [@yanokwa](https://github.com/yanokwa), [Nafundi](http://nafundi.com/)
+* Brent Atkinson [@batkinson](https://github.com/batkinson), [Medical Care Development International](http://www.mcdinternational.org/)
+* Adam Butler [@adamvert](https://github.com/adamvert), [eHealth Africa](https://www.ehealthafrica.org/)
+* Aurelio Di Pasquale [@aurdipas](https://github.com/aurdipas), [Swiss Tropical and Public Health Institute](https://www.swisstph.ch)
+* Hélène Martin [@lognaturel](https://github.com/lognaturel), [Nafundi](http://nafundi.com/)
+* Tom Smyth [@hooverlunch](https://github.com/hooverlunch), [Sassafras Tech Collective](http://sassafras.coop/)
+* Dickson Ukang’a [@ukanga](https://github.com/ukanga), [Ona](https://ona.io/)
  
 **Committers**
  


### PR DESCRIPTION
As announced at https://forum.opendatakit.org/t/odk-1-technical-steering-committee-tsc-established/11226

I included GitHub handles because that's often how we see each other so I think it's helpful to include them inline.