### PR TITLE
Change to support two TSCs

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -1,22 +1,22 @@
 **Governance Overview**
  
-The Open Data Kit (ODK) project is governed by multiple governing committees. There are two categories of governing bodies, the Project Management Committee (PMC) and the Technical Steering Committees (TSC). The PMC is the ultimate authority over the project. The TSC is the authority over the technical direction of the project’s tool suite. 
+The Open Data Kit (ODK) project is governed by the Project Management Committee (PMC) and two Technical Steering Committees (ODK 1 TSC, ODK 2 TSC). The PMC is the ultimate authority over the project while the TSCs have authority over the technical direction of their respective suites of software: ODK 1 and ODK 2.
  
-_Note: As ODK transitions out of the University of Washington, the current PMC’s authority will be transferred to a Transition Board. Once the transition is finished, the authority will transfer to a more permanent governance body (likely another PMC). The TSC will remain active throughout the transition process and post-transition._
+_Note: As ODK transitions out of the University of Washington, the current PMC's authority will be transferred to a Transition Board. Once the transition is finished, the authority will transfer to a more permanent governance body (likely another PMC). The TSCs will remain active throughout the transition process and post-transition._
  
-**Technical Steering Committee**
+**Technical Steering Committees**
  
-The Technical Steering Committee (TSC) is responsible for high-level technical direction of their  tool suite. The TSC has authority over all technical aspects including:
-* Suite roadmap (feature addition/removal, tool addition/removal,incorporating community feedback,etc.).
-* Forming appropriate Working Groups (e.g., User Feedback, Documentation, Translation) to gather the necessary community feedback before making decisions.
-* Technical resources (e.g., code repositories, servers)
-* Maintaining the list of Committers
+The Technical Steering Committees (ODK 1 TSC, ODK 2 TSC) are responsible for high-level technical direction of their respective suites of software. Each TSC has authority over all technical aspects of their suite including:
+* Suite roadmap (feature addition/removal, tool addition/removal, incorporating community feedback, etc.)
+* Forming appropriate suite Working Groups (e.g., User Feedback, Documentation, Translation) to gather the necessary community feedback before making decisions
+* The suite's technical resources (e.g., code repositories, servers)
+* Maintaining the list of the suite's Committers
+
+While it is expected that each suite's TSC will comply with this governance document in its own way, wherever possible, the TSCs should choose shared policies and infrastructure which allow for consistent process, but administrative separation across their respective suites of software. In the case where the TSCs cannot reach consensus on policies and infrastructure, the final decision will be made by a majority vote by the PMC.
  
-Wherever possible, the TSCs should choose shared policies and infrastructure which allow for consistent process, but administrative separation across tool suites. In the case where the TSCs cannot reach consensus on policies and infrastructure, the final decision will be made by a majority vote by the PMC.
- 
-Although the TSC may update the TSC governance (e.g. this document) as it finds appropriate, revisions are subject to PMC review and veto, as ultimate authority over governing the ODK project rests with the PMC. Any update to the TSC governing document must be approved by the majority of the PMC. It is expected that the TSC will have a collaborative relationship (perhaps some overlap in membership) with the PMC.
- 
-The current list of TSC members are:
+Although the TSCs may update the TSC governance (e.g., this document) as they find appropriate, revisions are subject to PMC review and veto. Any update to the TSCs governing document must be approved by the majority of the PMC. It is expected that the TSCs will have a collaborative relationship with each other and with the PMC.
+
+The current ODK 1 TSC members are:
 * Shobhit Agarwal [@shobhitagarwal1612](https://github.com/shobhitagarwal1612), [Tonbo Imaging](http://www.tonboimaging.com/)
 * Alex Anderson [@alxndrsn](https://github.com/alxndrsn), [Medic Mobile](https://medicmobile.org/)
 * Yaw Anokwa [@yanokwa](https://github.com/yanokwa), [Nafundi](http://nafundi.com/)
@@ -24,13 +24,15 @@ The current list of TSC members are:
 * Aurelio Di Pasquale [@aurdipas](https://github.com/aurdipas), [Swiss Tropical and Public Health Institute](https://www.swisstph.ch)
 * Hélène Martin [@lognaturel](https://github.com/lognaturel), [Nafundi](http://nafundi.com/)
 * Tom Smyth [@hooverlunch](https://github.com/hooverlunch), [Sassafras Tech Collective](http://sassafras.coop/)
-* Dickson Ukang’a [@ukanga](https://github.com/ukanga), [Ona](https://ona.io/)
+* Dickson Ukang'a [@ukanga](https://github.com/ukanga), [Ona](https://ona.io/)
  
+The ODK 2 TSC has not yet been formed. The University of Washington is currently the technical steward of ODK 2.
+
 **Committers**
  
-Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Commit/write access allows contributors to more easily carry on with their project related activities by giving them direct access to the project’s resources.
+Committers are community members who have shown that they are committed to the continued development of the suite through ongoing engagement with the community. Commit/write access allows contributors to more easily carry on with their suite-related activities by giving them direct access to the suite's resources.
  
-The project’s technical resources are managed by the TSC. Individuals making significant and valuable contributions are made Committers and given commit or write access to those resources. These individuals are identified by the TSC and their addition as Committers is discussed during the regular TSC meeting. The process for identifying and granting Committer access is determined by the TSC.
+The suite's technical resources are managed by the TSC. Individuals making significant and valuable contributions are made Committers and given commit or write access to those resources. These individuals are identified by the TSC and their addition as Committers is discussed during the regular TSC meeting. The process for identifying and granting Committer access is determined by the TSC.
  
 _Note: If you make a significant contribution and are not considered for commit/write access on the appropriate resource, file an issue, post on the forum, or contact a TSC member directly and it will be brought up in the next TSC meeting._
  
@@ -45,7 +47,7 @@ The current list of Committers is here:
 
 **TSC Membership**
  
-TSC will be elected via a public application process. The application requirements will focus on relevant experience, contributions to the project ecosystem, and availability to guide technical parts of the project. 
+TSC membership will be determined via a public application process. The application requirements will focus on relevant experience, contributions to the suite ecosystem, and availability to provide technical direction to the suite.
  
 The initial TSC membership will be determined by the PMC after a public application process and initial members will serve for 1 year.
 
@@ -53,13 +55,13 @@ After the initial selection by the PMC, members will be elected by a 2/3rds (rou
  
 The TSC must have at least three members, but there is no fixed size. The expected target is between 6 and 12, from a minimum of 3 separate organizations, to ensure long-term sustainability, adequate coverage of important areas of expertise, and ability to make decisions efficiently.
  
-There is no specific set of requirements or qualifications for TSC membership beyond these rules. That said, the likely best candidates for TSC members will be Committers.
+There is no specific set of requirements or qualifications for TSC membership beyond these rules. That said, the likely best candidates for TSC membership will be Committers.
  
-The TSC may add additional members to the TSC by a standard TSC motion. A TSC member may be removed from the TSC by voluntary resignation, or by a 2/3rds majority (rounded up). 
+The TSC may add additional members by a TSC motion. A TSC member may be removed by voluntary resignation, or by a 2/3rds majority (rounded up). 
  
 TSC members are expected to regularly participate in TSC activities. Members who have not consistently taken meaningful actions as TSC members in the past 3 months will be considered for removal. Examples of meaningful actions are participating regularly in calls, reviewing code, committing code, providing technical mentorship, leading working groups, etc.
  
-No more than 1/3 of the TSC members may be affiliated with the same organization. If removal or resignation of a TSC member, or a change of employment by a TSC member, creates a situation where more than 1/2 of the TSC membership belong to the same organization, the situation must be immediately remedied by the resignation or removal of one or more TSC members affiliated with the over-represented organization(s).
+No more than 1/3 of the TSC members may be affiliated with the same organization. If removal or resignation of a TSC member, or a change of employment by a TSC member, creates a situation where more than 1/2 of TSC membership belong to the same organization, the situation must be immediately remedied by the resignation or removal of one or more TSC members affiliated with the over-represented organization(s).
  
 Changes to TSC membership should be posted in the agenda, and may be suggested as any other agenda item.
  
@@ -69,9 +71,9 @@ The TSC will meet regularly (generally every two weeks). The meeting will be run
  
 The TSC will default to working in public, but sensitive topics (e.g., pre-disclosure security problems, confidential pre-agreement discussions with third parties, personal conflicts among personnel) should only be discussed on private channels.
  
-Items typically discussed by the TSC include project roadmap, feature addition/removal, etc. Items are added to the TSC agenda which are considered contentious or are modifications of governance, contribution policy, TSC membership, or release process. Working Groups that the TSC forms may also add items to the TSC agenda.
+Items typically discussed by the TSC include suite roadmap, feature addition/removal, etc. Items are added to the TSC agenda which are considered contentious or are modifications of governance, contribution policy, TSC membership, or release process. Working Groups that the TSC forms may also add items to the TSC agenda.
  
-The intention of the agenda is not to approve or review modifications to project resources. That should happen continuously on the relevant resources and are handled by the larger group of Committers.
+The intention of the agenda is not to approve or review modifications to suite resources. That should happen continuously on the relevant resources and are handled by the larger group of Committers.
  
 Any community member or contributor can ask that something be added to the next meeting's agenda by filing an issue or writing a forum post. Any Committer, TSC member, or the moderator can add the item to the agenda by adding the `tsc-agenda` tag to the issue or post.
  
@@ -83,7 +85,7 @@ The moderator is responsible for summarizing the discussion of each agenda item 
  
 **Decision Making**
 
-For internal project decisions, Committers shall operate under Lazy Consensus. The TSC shall establish appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods).
+For internal project decisions, Committers shall operate under Lazy Consensus. The TSC shall establish appropriate guidelines for implementing Lazy Consensus (e.g., expected notification and review time periods).
  
 The TSC follows a Consensus Seeking decision-making model. When an agenda item has appeared to reach a consensus, the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
  


### PR DESCRIPTION
The PMC has voted for the to-be-formed ODK 2 TSC to use the same goverance that the ODK 1 TSC is using.  

To that end, I've made a couple of changes to the document.
* Updated introduction to what we have on the ODK website (thus it's been approved)
* Replaced mentions of project with suite
* Added language to say we expect TSCs to have their own take on this document

I've also tweaked a bit of the grammar:
* Removed some unnecessary words
* Replaced smart quotes with dumb quotes 
* Replaced e.g. with e.g.

I've tried really hard to make sure we don't change the core meaning of the document and a review to confirm would be great.

As an aside, I toyed with replacing all "The TSC" with "Each TSC" or "Each suite's TSC" but it made for a pretty hard to parse. I think the document is pretty clear that starting from the Committer section, when we say "The TSC" we mean the suite's TSC. 