### PR TITLE
Make it easier to link directly, spelling

### DIFF
--- a/PMC-GOVERNANCE.md
+++ b/PMC-GOVERNANCE.md
@@ -35,7 +35,7 @@ Users are community members who have a need for the project. They are the most i
 
 The project asks its users to participate in the project and community as much as possible. User contributions enable the project team to ensure that they are satisfying the needs of those users. Common user contributions include (but are not limited to):
 
-*   evangelising about the project (e.g. a link on a website and word-of-mouth awareness raising)
+*   evangelizing about the project (e.g. a link on a website and word-of-mouth awareness raising)
 *   informing developers of strengths and weaknesses from a new user perspective
 *   providing moral support (a ‘thank you’ goes a long way)
 *   providing financial support (the software is open source, but its developers need to eat)

--- a/TSC-GOVERNANCE.md
+++ b/TSC-GOVERNANCE.md
@@ -2,6 +2,8 @@
 
 * [Overview](#overview)
 * [Roles and responsibilities](#roles-and-responsibilities)
+	* [TSC 1](#tsc-1)
+	* [TSC 2](#tsc-2)
 * [Committers](#committers)
 * [Membership](#membership)
 * [Meetings](#meetings)
@@ -26,6 +28,8 @@ While it is expected that each suite's TSC will comply with this governance docu
 
 Although the TSCs may update the TSC governance (e.g., this document) as they find appropriate, revisions are subject to PMC review and veto. Any update to the TSCs governing document must be approved by the majority of the PMC. It is expected that the TSCs will have a collaborative relationship with each other and with the PMC.
 
+#### <a name="tsc-1"></a>TSC 1
+
 TSC 1 is responsible for the ODK Suite: ODK Collect, ODK Aggregate, ODK XLSForm, ODK Build, ODK Briefcase, ODK Central, ODK JavaRosa, and the ODK XForms specification. Standard operating procedures for TSC 1 can be found at [TSC 1](TSC-1/).
 
 The current TSC 1 members are:
@@ -39,6 +43,8 @@ The current TSC 1 members are:
 * Martijn van de Rijdt ([@martijnr](https://github.com/martijnr)), [Enketo](http://enketo.org)
 * Tom Smyth ([@hooverlunch](https://github.com/hooverlunch)), [Sassafras Tech Collective](http://sassafras.coop/)
 * Dickson Ukang'a ([@ukanga](https://github.com/ukanga)), [Ona](https://ona.io/)
+
+#### <a name="tsc-2"></a>TSC 2
 
 TSC 2 is responsible for the ODK-X Suite: ODK-X Application Designer, ODK-X Services, ODK-X Survey, ODK-X Cloud Endpoints, ODK-X Suitcase, ODK-X Tables, and ODK-X Scan. Standard operating procedures for TSC 2 can be found at [TSC 2](TSC-2/).
 


### PR DESCRIPTION
Adding this links makes it easier for us to link directly to the list of tools that each TSC is responsible for. Also, we use American English everywhere, so we should be consistent.