### PR TITLE
new TSC-1 roadmap document

### DIFF
--- a/TSC-1/ROADMAP.md
+++ b/TSC-1/ROADMAP.md
@@ -1,1 +1,19 @@
-TSC-1 Roadmap
+# TSC-1 Roadmap
+
+### Document: https://github.com/opendatakit/roadmap/projects/1
+
+### Purpose
+The purpose of the TSC-1 roadmap is to document and track proposed and ongoing changes to the ODK Project and/or associated projects/tools.
+
+### Roadmap categories
+* **"Proposed"**: ideas or new features that are currently being discussed and details worked out, preferably via a Forum thread.
+* **"Under Review"**: roadmap items that recently have, or currently are, on a TSC agenda for review.
+* **"Approved"**: roadmap items that have been approved by TSC consensus (but not yet assigned to a specific developer). All approved items must have an associated github issue. Typically these are planned for release in the next 1-6 months.
+* **"In Progress"**: roadmap items whose github issue has been assigned to a developer (or owner) and is being worked on. Typically these will be completed in the next 1-3 months.
+* **"Done"**: roadmap items whose github issue has been closed (ie completed). Done items will be purged from appearing on this roadmap after approx 1 month.
+
+### Rationale
+The idea is that features will progress in a somewhat formal fashion thru these category stages, with specific recommended requirements needing to be met to progress from one stage to the next (although anyone with permision may add/move items from categories at any time). Specifically, prior to TSC approval, features, new roadmap ideas, project-related proposals, etc can be somewhat nebulous and may be discussed in a variety of suitable forums; eg simply placeholder notes in the roadmap, or ongoing public discussions in a related ODK forum thread, or more development-focussed discussion in an associated github issue, etc. However, once a feature/idea/proposal is formally 'approved' (TDB) by the TSC, it needs to exist as a specific github issue associated with a specific github project (including goverance) for tracking purposes. The state of the feature/idea/proposal in the roadmap should then simply mirror its github state, thus reducing inconsistencies; github being the ground-truth.
+
+### Permissions
+Any current TSC-1 member has permission to add, remove, move items on the roadmap, although this should normally be done after consulation with the TSC-1 group.

--- a/TSC-1/ROADMAP.md
+++ b/TSC-1/ROADMAP.md
@@ -1,0 +1,1 @@
+TSC-1 Roadmap


### PR DESCRIPTION
Proposal for adding new document to TSC-1 governance to describe and document recent changes to the TSC roadmap (and deprecated parking lot)