### PR TITLE
Remove TAB, ODK-X, Tool governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ As stated above, anybody may submit a pull request against any of the repositori
 
 ## Amendments
 
-Revisions to any document in this repository must be approved by both Get ODK Inc. Even though these documents exist within an ODK repository, this requirement supersedes the change approval policy above. Committers should not effect changes to documents in this repository without the approval of Get ODK Inc. Exceptions may be made for small changes such as typographical errors.
+Revisions to any document in this repository must be approved by Get ODK Inc. Even though these documents exist within an ODK repository, this requirement supersedes the change approval policy above. Committers should not effect changes to documents in this repository without the approval of Get ODK Inc. Exceptions may be made for small changes such as typographical errors.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Governance Overview
 
-The ODK project is governed by Get ODK Inc. under the supervision of its Technical Advisory Board. It is separate from the ODK-X project as per the terms of the [Separation MOU](SEPARATION-MOU.md).
-
-Get ODK Inc. and its Technical Advisory Board are guided first and foremost by the project's [Code of Conduct](CODE-OF-CONDUCT.md) and [Mission and Values](MISSION-AND-VALUES.md). The remainder of this document lays out how specific decisions are made.
+The ODK project is governed by Get ODK Inc. Get ODK Inc. is guided first and foremost by the project's [Mission and Values](MISSION-AND-VALUES.md) and [Code of Conduct](CODE-OF-CONDUCT.md). The remainder of this document lays out how specific decisions are made.
 
 ## Get ODK Inc.
 
@@ -12,27 +10,21 @@ In recognition of these facts, Get ODK Inc., a corporation in the U.S. State of 
 
 Get ODK Inc. strives to preserve ODK as a healthy and bona fide open source project and sustains its operations through ODK-related business activites (or otherwise).
 
-## Technical Advisory Board
-
-The Technical Advisory Board (TAB) represents the broader ODK community. It reviews and gives feedback on major roadmap decisions, new designs, specifications, features, and protocol changes.
-
-The TAB was formerly the Technical Steering Committee (TSC). When Get ODK Inc. was created, the TAB agreed to become an advisory body to the new entity and change its name. Get ODK Inc. commits to maintaining the TAB indefinitely as part of its commitment to the open source community.
-
-The TAB's membership and decision making process are defined in the [TAB's internal governance policy](TAB-GOVERNANCE.md).
-
 ## Code
 
 As ODK is an open source project, anybody may file issues on or propose code changes to any of the various ODK repositories. Proposed code changes must be approved by a project Committer.
 
-ODK code is permissively licensed with code copyright remaining with the original author. In this sense, no one entity "owns" the project's intellectual assets. The release process for all tools is controlled by Get ODK Inc. All ODK-related online properties such as software-as-a-service accounts, hosting accounts, social media accounts, and so forth are in the name of Get ODK Inc., and all expenses for same are borne by Get ODK Inc.
+ODK code is permissively licensed with code copyright remaining with the original author. In this sense, no one entity "owns" the project's code. And while ODK's code is permissively licensed, its trademarks, service marks, and logos are not. ODK's brand is entirely owned and controlled by Get ODK Inc.
+
+The release process for all tools is controlled by Get ODK Inc. All ODK-related online properties such as software-as-a-service accounts, hosting accounts, social media accounts, and so forth are in the name of Get ODK Inc., and all expenses for same are borne by Get ODK Inc.
 
 ### Committers
 
 Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Commit/write access allows contributors to more easily carry on with their project-related activities by giving them direct access to the project's resources.
 
-Get ODK Inc. awards Committer status to individuals making significant and valuable contributions to the project. Current Committers and the TAB may also suggest individuals deserving of Committer access, but Get ODK Inc. has final say.
+Get ODK Inc. awards Committer status to individuals making significant and valuable contributions to the project. Current Committers may also suggest individuals deserving of Committer access, but Get ODK Inc. has final say.
 
-_Note: If you make a significant contribution and are not considered for commit/write access on the appropriate resource, file an issue, post on the forum, or contact a TAB member directly and it will be brought up at the next TAB meeting._
+_Note: If you make a significant contribution and are not considered for commit/write access on the appropriate resource, file an issue, post on the forum, or contact Get ODK Inc. directly._
 
 If a Committer becomes inactive, having not participated substantially in the project for six months or more, their Committer status will be revoked. They may regain status again by resuming substantial participation.
 
@@ -46,20 +38,16 @@ Proposed code changes must be approved by a project Committer with sufficient ex
 
 In the case of changes proposed by an existing Committer, an additional Committer is required for review.
 
-Committers should elevate significant or controversial modifications to the TAB for discussion. The TAB should seek to achieve consensus on the question and offer its recommendation.
+Committers should elevate significant or controversial modifications to Get ODK Inc. for discussion. Get ODK Inc. should seek to achieve consensus on the question and offer its recommendation.
 
 As Get ODK Inc. has commit access and controls the release process for all tools, it effectively has final say on any code changes. The above procedures are designed to foster a collaborative, community-oriented process, and should be followed in most cases.
 
 ## Roadmap
 
-A "project roadmap" is the plan of upcoming changes to a project's code. In ODK projects, the Get ODK Inc. and the TAB collaborate to set the roadmap. Suitability of items for the roadmap is determined by community need and the availability of resources to support development.
+A "project roadmap" is the plan of upcoming changes to a project's code. In ODK projects, the Get ODK Inc. sets the roadmap. Suitability of items for the roadmap is determined by community need and the availability of resources to support development.
 
-As stated above, anybody may submit a pull request against any of the repositories. The change approval section above covers how such pull requests may be approved. It should be noted, though, that major changes to the project stand a much better chance of being accepted if they are on the roadmap and/or if Get ODK Inc. and the TAB have agreed in advance they are a good fit for the project and that the chosen design and implementation stategy are suitable.
-
-## Tools
-
-ODK is a community that produces free and open-source software for collecting, managing, and using data in resource-constrained environments. The community may allow certain other projects adhering to that vision to join ODK in order to contribute to and benefit from its brand, community, and vitality. The [Tool Governance](TOOL-GOVERNANCE.md) document defines the specifics of how this can happen.
+As stated above, anybody may submit a pull request against any of the repositories. The change approval section above covers how such pull requests may be approved. It should be noted, though, that major changes to the project stand a much better chance of being accepted if they are on the roadmap and/or if Get ODK Inc. have agreed in advance they are a good fit for the project and that the chosen design and implementation stategy are suitable.
 
 ## Amendments
 
-Revisions to any document in this repository must be approved by both Get ODK Inc. and the Technical Advisory Board. Even though these documents exist within an ODK repository, this requirement supersedes the change approval policy above. Committers should not effect changes to documents in this repository without the approval of Get ODK Inc. and the TAB. Exceptions may be made for small changes such as typographical errors.
+Revisions to any document in this repository must be approved by both Get ODK Inc. Even though these documents exist within an ODK repository, this requirement supersedes the change approval policy above. Committers should not effect changes to documents in this repository without the approval of Get ODK Inc. Exceptions may be made for small changes such as typographical errors.


### PR DESCRIPTION
* Remove the TAB because it's been wound down
* Remove ODK-X because confusion about it is not common
* Remove Tool Governance because it's now Get ODK's decision
* Add language about trademarks